### PR TITLE
Add simple commands for test and compile to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "test": "test"
   },
   "scripts": {
+    "test": "hardhat test",
+    "compile": "hardhat compile",
     "prettier": "prettier --write contracts/RealityCards.sol",
     "update-graph-abis": "npx buidler compile && cp ./artifactsTruffle/RCFactory.json ../RealityCards-Client/subgraph/abis/RealityCardsFactory.json && cp ./artifactsTruffle/RCTreasury.json ../RealityCards-Client/subgraph/abis/RealityCardsTreasury.json && cp ./artifactsTruffle/RCMarket.json ../RealityCards-Client/subgraph/abis/RealityCardsMarket.json",
     "coverage": "hardhat coverage"


### PR DESCRIPTION
Just for convenience and consistency (it is possible that we have different versions of hardhat globally on our laptops - but we will have the same version if we use the hardhat version from the node_modules folder)